### PR TITLE
Add `healthcheck` to `database` service and `depends_on` check to services dependent on `database`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,8 @@ services:
     build:
       context: .
     depends_on:
-      - database
+      database:
+        condition: service_healthy
     ports:
       - $SERVICE_PORT:$SERVICE_PORT
     command: ["serve", "--env", "production", "--hostname", $SERVICE_NAME, "--port", $SERVICE_PORT]
@@ -39,8 +40,9 @@ services:
     image: tilde:latest
     build:
       context: .
-    depends_on: 
-      - database
+    depends_on:
+      database:
+        condition: service_healthy
     command: ["migrate", "--yes"]
     deploy:
       replicas: 0
@@ -49,7 +51,8 @@ services:
     build:
       context: .
     depends_on:
-      - database
+      database:
+        condition: service_healthy
     command: ["migrate", "--revert", "--yes"]
     deploy:
       replicas: 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,3 +66,8 @@ services:
       POSTGRES_DB: $DATABASE_NAME
     ports:
       - $DATABASE_PORT:$DATABASE_PORT
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d $$POSTGRES_DB -U $$POSTGRES_USER"] # Use double `$` to expand the environment variables during execution
+      interval: 5s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
# Why?
- The `app` service is dependent on the `database` service. The `app` service should only start when the `database` service passes the `healthcheck` (same applies to `migrate` and `revert` subcommands).

# What?
- Add `healthcheck` to the `depends_on` configuration in `docker-compose` for services depending on the `database` service
- Configure `healthcheck` of the `database` to run `pg_isready` at five second intervals.



