### PR TITLE
Feature: Tag the latest `Docker` image with a commit hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,13 @@
 # ================================
 FROM swift:5.6-focal as build
 
+# Image tag (the last git commit in short notation) and timestamp of creation
+ARG VERSION
+ARG BUILD_TIMESTAMP
+
+ENV VERSION=$VERSION
+ENV BUILD_TIMESTAMP=$BUILD_TIMESTAMP
+
 # Install OS updates and, if needed, sqlite3
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true \
     && apt-get -q update \

--- a/tag-image.sh
+++ b/tag-image.sh
@@ -1,0 +1,12 @@
+#!/bin/bash 
+VERSION=$(git log -1 --pretty=%h)
+REPO="robinsalehjan/tilde:"
+
+TAG="$REPO$VERSION"
+LATEST="${REPO}latest"
+
+BUILD_TIMESTAMP=$( date '+%F_%H:%M:%S' )
+
+docker build -t "$TAG" -t "$LATEST" --build-arg VERSION="$VERSION" --build-arg BUILD_TIMESTAMP="$BUILD_TIMESTAMP" . 
+docker push "$TAG" 
+docker push "$LATEST"


### PR DESCRIPTION
# Why?
- `latest` is just a default value that `Docker` assigns to images when no tag has been specified.

# What?
- Retrieve the latest `git commit` hash in short notation by running: `git log -p --pretty=%h` and assign to `tag` and `latest` when pushing the `image` to [image registry](https://hub.docker.com/repository/docker/robinsalehjan/tilde).
- Add `tag-image.sh` script to automate this 😄 