### PR TITLE
Internal: Add `init: true` to services in `docker-compose`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ networks:
 services:
   app:
     image: tilde:latest
+    init: true
     env_file: .env
     container_name: $SERVICE_NAME
     build:
@@ -38,6 +39,7 @@ services:
     command: ["serve", "--env", "production", "--hostname", $SERVICE_NAME, "--port", $SERVICE_PORT]
   migrate:
     image: tilde:latest
+    init: true
     build:
       context: .
     depends_on:
@@ -48,6 +50,7 @@ services:
       replicas: 0
   revert:
     image: tilde:latest
+    init: true
     build:
       context: .
     depends_on:
@@ -58,6 +61,7 @@ services:
       replicas: 0
   database:
     image: postgres:14-alpine
+    init: true
     env_file: .env
     container_name: $DATABASE_NAME
     volumes:


### PR DESCRIPTION
# Why?
- Run a `init process (PID 1)` inside the container that forwards signals and terminates (zombie) processes.
- Read more about the [Docker and the PID 1 zombie reaping problem](https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/)

# What?
- Add the `init: true` config to the services declared in `docker-compose`.